### PR TITLE
[BUG FIX] Bug fix for advanced filtering modal reset feature

### DIFF
--- a/src/components/custom/general/MultiTypedInput.tsx
+++ b/src/components/custom/general/MultiTypedInput.tsx
@@ -84,8 +84,10 @@ export function FlexibleInput({
 
   // Initialize values based on prop
   useEffect(() => {
+    console.log(inputType, value, type)
     switch (inputType) {
       case "exact":
+      default:
         setExactValue((value ?? defaultMultiTypeNullValue) as defaultValue)
         break
       case "regex":

--- a/src/components/custom/jobsTable/actionDropdown.tsx
+++ b/src/components/custom/jobsTable/actionDropdown.tsx
@@ -216,7 +216,7 @@ export default function ActionDropdown({
             >
               <DockIcon />
               <span>Custom run</span>
-              <DropdownMenuShortcut>⌘+⇧+R</DropdownMenuShortcut>
+              <DropdownMenuShortcut>⌘+⇧+E</DropdownMenuShortcut>
             </DropdownMenuItemExtended>
           </JobExecutionDialog>
           <DropdownMenuItemExtended

--- a/src/features/jobsTable/jobsPage.tsx
+++ b/src/features/jobsTable/jobsPage.tsx
@@ -81,12 +81,12 @@ export default function JobsPage() {
   )
 
   const onAdvancedFilterChange = useCallback(
-    (value: any) => {
+    (value: any, reset?: boolean) => {
       if (!value) {
         avFilteringRef.current?.reset()
       }
-      setAdvancedFilters(value)
-      updateTableData(undefined, value)
+      setAdvancedFilters(reset ? undefined : value)
+      updateTableData(undefined, reset ? undefined : value)
     },
     [updateTableData],
   )


### PR DESCRIPTION
**Bug fixes :**
- Fixing the AdvFilters modal reset button, it now functions like the external button. It's effect on the execution form is the same, resetting the full previewed list

**Improvements :**
- Fixing a visual bug with the keyboard shortcut for the custom run job action, the shortcut now shows ⌘+⇧+E instead of ⌘+⇧+R
