### PR TITLE
[BUGFIX] adding even log page missing query

### DIFF
--- a/src/features/system/eventLog.tsx
+++ b/src/features/system/eventLog.tsx
@@ -17,6 +17,7 @@ export function EventLog() {
     }),
     initialLogsFilter: period,
     mergeOutputStreams: true,
+    logQuery: `{eventName=~".+"}`,
   })
 
   const onPeriodFilterChange = useCallback((period?: DateRange) => {


### PR DESCRIPTION
**Notes :**
- We added the possibility to use specific query for loki logs, but did not add it on the eventLog page. This will fix that 