### PR TITLE
[DEV-IMP] Updating defaults on Dashboard's events charts to days 

### DIFF
--- a/src/components/custom/charts/AllEventStats.tsx
+++ b/src/components/custom/charts/AllEventStats.tsx
@@ -79,8 +79,8 @@ export function AllEventStats(props: AllEventStatsProps) {
     from: defaultDateRange.from,
     to: defaultDateRange.to,
   })
-  const [period, setPeriod] = useState(props.period ?? 60)
-  const [periodUnit, setPeriodUnit] = useState<string>("min")
+  const [period, setPeriod] = useState(props.period ?? 1)
+  const [periodUnit, setPeriodUnit] = useState<string>("d")
 
   const [activeTab, setActiveTab] = useState("chart")
 

--- a/src/components/ui/date-picker-presets.tsx
+++ b/src/components/ui/date-picker-presets.tsx
@@ -53,9 +53,15 @@ const presetDates: DateRangeExtended[] = [
     label: "Last month",
     days: 30,
   },
+  {
+    from: subDays(new Date(), 180),
+    to: new Date(),
+    label: "Last 6 month",
+    days: 180,
+  },
 ]
 
-export const defaultDateRange = presetDates?.slice(-1)[0]
+export const defaultDateRange = presetDates?.slice(-2)[0]
 
 export function DatePickerWithPresets(props: DatePickerWithPresetsProps) {
   const [date, setDate] = React.useState<DateRange | undefined>(


### PR DESCRIPTION
**Improvement :**
- Adding last 6 month default date range, an easier selection for longer tasks 
- Updating default period unit to "days" instead of hours on Dashboard's events chart, a much more pleasant first view