### PR TITLE
[BugFix] Fixing nginx 1.29.3 version for the docker build (temp)

### DIFF
--- a/DOCKERFILE
+++ b/DOCKERFILE
@@ -10,7 +10,7 @@ COPY . ./
 RUN npm run build
 
 # production environment
-FROM nginx:1.29.4-alpine
+FROM nginx:1.29.3-alpine
 COPY --from=build /app/dist /usr/share/nginx/html
 
 ARG SERVER_ENDPOINT=http://localhost:3000


### PR DESCRIPTION
**BugFix :**
- Fixing the nginx:alpine version to the 1.29.3 version as the newer versions have an issue when installing bash, this is a temporary fix as this version seems to have a lot of potential vulnerabilities 