### PR TITLE
[DEV-BugFix] fix missing encrypted badge due to variable name change

### DIFF
--- a/src/components/custom/configs/configInputCombo.tsx
+++ b/src/components/custom/configs/configInputCombo.tsx
@@ -81,7 +81,7 @@ export default function ConfigInputCombo({
               }
             />
           ) : (
-            item.encrypted && <Badge variant="secondary">Encrypted</Badge>
+            item.is_encrypted && <Badge variant="secondary">Encrypted</Badge>
           )}
           {editMode && (
             <Label htmlFor={`encrypted-${item.id}`} className="text-sm">


### PR DESCRIPTION
### Bug fixes : 
- the encrypted badge will now show in view mode for encrypted values, the variable name changed to `is_encrypted` and this updates the view component with that in mind