### PR TITLE
[BugFix-DEV] Fixing getting filters from undefined props

### DIFF
--- a/src/hooks/useProxies.tsx
+++ b/src/hooks/useProxies.tsx
@@ -17,7 +17,7 @@ export function useProxies(props?: UseProxyProps) {
   const queryClient = useQueryClient()
 
   const { data, isLoading } = useQuery({
-    queryKey: ["proxies", "all", props.filters],
+    queryKey: ["proxies", "all", props?.filters],
     queryFn: () =>
       systemService.getAllProxies({
         limit: props?.filters?.limit,


### PR DESCRIPTION
### BugFixes : 
- Adding null operator for when trying to use `props?.filters` for `queryKeys` in the `useProxies` hook