### PR TITLE
[DEV-IMP] Hiding keybindings on buttons when it's not necessary

### DIFF
--- a/src/components/custom/DrawerMenuConfigurator.tsx
+++ b/src/components/custom/DrawerMenuConfigurator.tsx
@@ -11,13 +11,8 @@ import { useCallback, useEffect, useRef, useState } from "react"
 import ConfirmationDialogAction, {
   ConfirmationDialogActionType,
 } from "@/components/confirmationDialogAction"
-import { DropdownMenuItem } from "@/components/ui/dropdown-menu"
-import { jobActions } from "@/features/jobsTable/interfaces"
 import { useHotkeys } from "react-hotkeys-hook"
-import HotKeyButton from "@/components/custom/HotKeyButton"
 import { verifyUserConnection } from "@/utils/authUtils"
-import ButtonWithStrCut from "@/components/custom/general/ButtonWithStrCut"
-import { ButtonGroup } from "@/components/ui/button-group"
 import { ButtonWithTooltip } from "@/components/custom/general/ButtonWithTooltip"
 
 export default function DrawerMenuConfigurator() {
@@ -185,6 +180,7 @@ export default function DrawerMenuConfigurator() {
                   <ButtonWithTooltip
                     tooltipContent={`(⌘⌥${i + 1})`}
                     keyBinding={["ctrl+alt+" + (i + 1), "meta+alt+" + (i + 1)]}
+                    hideKeyboardShortcut={true}
                     variant={"default"}
                     size={"icon"}
                     onClick={() => setNewTargetServer(e)}

--- a/src/components/custom/configs/ConfigAside.tsx
+++ b/src/components/custom/configs/ConfigAside.tsx
@@ -3,7 +3,7 @@ import useDialogueManager from "@/hooks/useDialogManager"
 import { Bell, FileText, Plus, Settings } from "lucide-react"
 import { useCallback } from "react"
 import { cn } from "@/lib/utils"
-import { ConfigViewType } from "@/features/system/configs"
+import { ConfigViewType } from "@/models/configs"
 
 interface ConfigAsideProps {
   activeView: ConfigViewType
@@ -67,6 +67,8 @@ export function ConfigAside({ activeView, onViewChange }: ConfigAsideProps) {
           tooltipDelay={0}
           aria-label={item.label}
           keyBinding={item.keyBinding}
+          hideKeyboardShortcut={true}
+          useInForm={true}
         >
           <item.icon className="h-5 w-5" />
           {activeView === item.view && (

--- a/src/components/custom/general/ButtonWithStrCut.tsx
+++ b/src/components/custom/general/ButtonWithStrCut.tsx
@@ -9,6 +9,7 @@ export interface ButtonWithStrCutProps extends ButtonProps {
   keyBinding?: string | string[]
   onAction?: (arg0: KeyboardEvent) => void
   useInForm?: Options["enableOnFormTags"]
+  hideKeyboardShortcut?: boolean
 }
 
 const ButtonWithStrCut = React.forwardRef<
@@ -21,6 +22,7 @@ const ButtonWithStrCut = React.forwardRef<
       onAction,
       useInForm,
       children,
+      hideKeyboardShortcut,
       ...props
     }: ButtonWithStrCutProps,
     ref,
@@ -51,14 +53,19 @@ const ButtonWithStrCut = React.forwardRef<
       : keyBinding
     return (
       <Button ref={newRef} {...props}>
-        {children}{" "}
-        <span className="font-mono text-[12px]">
-          {keyBindingLabel
-            ? "(" +
-              formatForDisplay(keyBindingLabel, { separatorToken: "" }) +
-              ")"
-            : ""}
-        </span>
+        {children}
+        {!hideKeyboardShortcut && (
+          <>
+            {" "}
+            <span className="font-mono text-[12px]">
+              {keyBindingLabel
+                ? "(" +
+                  formatForDisplay(keyBindingLabel, { separatorToken: "" }) +
+                  ")"
+                : ""}
+            </span>
+          </>
+        )}
       </Button>
     )
   },

--- a/src/components/custom/notifications/NotificationAside.tsx
+++ b/src/components/custom/notifications/NotificationAside.tsx
@@ -1,11 +1,4 @@
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip"
-import { Button } from "@/components/ui/button"
-import { Inbox, Circle, AtSign, Settings } from "lucide-react"
+import { Inbox, Circle } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { NotificationType } from "@/models/notifications"
 import { ButtonWithTooltip } from "@/components/custom/general/ButtonWithTooltip"
@@ -65,6 +58,8 @@ export function NotificationAside({
           tooltipDelay={0}
           aria-label={item.label}
           keyBinding={item.keyBinding}
+          hideKeyboardShortcut={true}
+          useInForm={true}
         >
           <item.icon className="h-5 w-5" />
           {activeView === item.view && (


### PR DESCRIPTION
### Improvements : 
- Hide `keyBindings` on notifications and config small sidebar buttons
- Hide `Keybindings` from config slider panel