### PR TITLE
[DEV-IMP] Fixing text wrapping on eventLog logViewer component

### DIFF
--- a/src/features/system/eventLog.tsx
+++ b/src/features/system/eventLog.tsx
@@ -82,6 +82,7 @@ export function EventLog() {
                 <LiveLogViewer
                   initialLogs={logs.map(e => e.fullMessage)}
                   newLogs={latestLogs.map(e => e.fullMessage)}
+                  wrapLines={false}
                 />
               ) : (
                 <Spinner


### PR DESCRIPTION
### Improvements : 
- fix text wrapping for `eventLog` log viewer, it will show object errors much better